### PR TITLE
accept optional source address for rsync of data, fixes #8

### DIFF
--- a/packaging/general/sie-dns-sensor/etc/default/sie-dns-sensor
+++ b/packaging/general/sie-dns-sensor/etc/default/sie-dns-sensor
@@ -7,6 +7,7 @@ maxper="16"
 
 channel="ch202"
 interface="eth0"
+# rsync_source="2001:db8::1" # optional
 DNSQR_RES_ADDRS="192.0.2.1, 2001:db8::1"
 
 syslog_priority="local5.info"

--- a/packaging/general/sie-dns-sensor/usr/lib/sie/functions
+++ b/packaging/general/sie-dns-sensor/usr/lib/sie/functions
@@ -47,7 +47,13 @@ fi
 
 ### internal settings
 
-ssh_cmd="ssh -p %p -i $uploadkey -o UserKnownHostsFile=$knownhosts -o StrictHostKeyChecking=yes"
+if [ -z "$rsync_source" ]; then
+    source_cmd=""
+else
+    source_cmd="-b $rsync_source"
+fi
+
+ssh_cmd="ssh $source_cmd -p %p -i $uploadkey -o UserKnownHostsFile=$knownhosts -o StrictHostKeyChecking=yes"
 rsync_args="--timeout=10 --remove-source-files"
 submitservice="_rsync._tcp."
 


### PR DESCRIPTION
- adds an optional config parameter `rsync_source`, which will set the bind_interface option on the ssh session used by rsync when present